### PR TITLE
Change coordinates and direction to f32

### DIFF
--- a/engine/src/actions/movement.rs
+++ b/engine/src/actions/movement.rs
@@ -68,29 +68,29 @@ mod tests {
 
     #[test]
     fn go_left() {
-        expect_position(0, 0, left, -1, 0);
-        expect_position(1, 1, left, 0, 1);
+        expect_position(0.0, 0.0, left, -1.0, 0.0);
+        expect_position(1.0, 1.0, left, 0.0, 1.0);
     }
 
     #[test]
     fn go_right() {
-        expect_position(0, 0, right, 1, 0);
-        expect_position(1, 1, right, 2, 1);
+        expect_position(0.0, 0.0, right, 1.0, 0.0);
+        expect_position(1.0, 1.0, right, 2.0, 1.0);
     }
 
     #[test]
     fn go_down() {
-        expect_position(0, 0, down, 0, 1);
-        expect_position(1, 1, down, 1, 2);
+        expect_position(0.0, 0.0, down, 0.0, 1.0);
+        expect_position(1.0, 1.0, down, 1.0, 2.0);
     }
 
     #[test]
     fn go_up() {
-        expect_position(0, 0, up, 0, -1);
-        expect_position(1, 1, up, 1, 0);
+        expect_position(0.0, 0.0, up, 0.0, -1.0);
+        expect_position(1.0, 1.0, up, 1.0, 0.0);
     }
 
-    fn expect_position(x: i8, y: i8, f: fn(i32) -> ActionData, ex: i8, ey: i8) {
+    fn expect_position(x: f32, y: f32, f: fn(i32) -> ActionData, ex: f32, ey: f32) {
         let world: &mut World = &mut World::new();
         let entity = world.register(Entity::new(0, Coordinate::new(x, y)));
 
@@ -98,7 +98,7 @@ mod tests {
         process(world, left);
 
         let new_entity = world.get_entity(entity.id).unwrap();
-        assert_eq!(new_entity.coord.x, ex);
-        assert_eq!(new_entity.coord.y, ey);
+        assert!(new_entity.coord.is_at_x(ex));
+        assert!(new_entity.coord.is_at_y(ey));
     }
 }

--- a/engine/src/game/runner.rs
+++ b/engine/src/game/runner.rs
@@ -29,7 +29,7 @@ mod tests {
     #[test]
     fn run_actions() {
         let mut world: World = World::new();
-        let entity = world.register(Entity::new(0, Coordinate::new(0, 0)));
+        let entity = world.register(Entity::new(0, Coordinate::new(0.0, 0.0)));
 
         let move_down = movement::down(entity.id);
         world.register_action(move_down);
@@ -45,7 +45,7 @@ mod tests {
         assert!(entity_option.is_some());
 
         let entity = entity_option.unwrap();
-        assert_eq!(1, entity.coord.x);
-        assert_eq!(1, entity.coord.y);
+        assert!(entity.coord.is_at_x(1.0));
+        assert!(entity.coord.is_at_y(1.0));
     }
 }

--- a/engine/src/models/coordinate.rs
+++ b/engine/src/models/coordinate.rs
@@ -1,19 +1,35 @@
 #[derive(Clone, Default, Debug, Copy)]
 pub struct Coordinate {
-    pub x: i8,
-    pub y: i8,
+    pub x: f32,
+    pub y: f32,
 }
+
+const ERROR_MARGIN: f32 = std::f32::EPSILON;
 
 impl Coordinate {
     /// Returns a new `Coordinate`
-    pub fn new(x: i8, y: i8) -> Coordinate {
+    pub fn new(x: f32, y: f32) -> Coordinate {
         Coordinate { x, y }
     }
 
     pub fn is_adjacent(self, other: Coordinate) -> bool {
-        let dx: i8 = self.x - other.x;
-        let dy: i8 = self.y - other.y;
-        dx < 2 && dx > -2 && dy < 2 && dy > -2
+        let dx: f32 = self.x - other.x;
+        let dy: f32 = self.y - other.y;
+        dx < 2.0 && dx > -2.0 && dy < 2.0 && dy > -2.0
+    }
+
+    pub fn is_at_x(self, x: f32) -> bool {
+        (self.x - x).abs() < ERROR_MARGIN
+    }
+
+    pub fn is_at_y(self, y: f32) -> bool {
+        (self.y - y).abs() < ERROR_MARGIN
+    }
+}
+
+impl PartialEq for Coordinate {
+    fn eq(&self, other: &Coordinate) -> bool {
+        self.is_at_x(other.x) && self.is_at_y(other.y)
     }
 }
 
@@ -23,21 +39,42 @@ mod tests {
 
     #[test]
     fn create_new() {
-        let coord: Coordinate = Coordinate::new(1, 2);
-        assert_eq!(1, coord.x);
-        assert_eq!(2, coord.y);
+        let coord: Coordinate = Coordinate::new(1.0, 2.0);
+        assert!(coord.is_at_x(1.0));
+        assert!(coord.is_at_y(2.0));
+    }
+
+    #[test]
+    fn is_at() {
+        let coord: Coordinate = Coordinate::new(1.0, 1.0);
+        assert!(coord.is_at_x(1.0));
+        assert!(!coord.is_at_x(1.1));
+        assert!(!coord.is_at_x(1.01));
+
+        assert!(coord.is_at_y(1.0));
+        assert!(!coord.is_at_y(0.09));
+    }
+
+    #[test]
+    fn is_eq() {
+        let coord1: Coordinate = Coordinate::new(1.0, 1.0);
+        let coord2: Coordinate = Coordinate::new(1.0, 1.0);
+        let coord3: Coordinate = Coordinate::new(1.0, 2.0);
+
+        assert!(coord1 == coord2);
+        assert!(coord2 != coord3);
     }
 
     #[test]
     fn is_adjacent() {
-        is_adjacent_coords(0, 0, 1, 0, true);
-        is_adjacent_coords(0, 0, 1, 1, true);
-        is_adjacent_coords(-1, 0, 0, 0, true);
+        is_adjacent_coords(0.0, 0.0, 1.0, 0.0, true);
+        is_adjacent_coords(0.0, 0.0, 1.0, 1.0, true);
+        is_adjacent_coords(-1.0, 0.0, 0.0, 0.0, true);
 
-        is_adjacent_coords(-1, 0, 0, 5, false);
+        is_adjacent_coords(-1.0, 0.0, 0.0, 5.0, false);
     }
 
-    fn is_adjacent_coords(x1: i8, y1: i8, x2: i8, y2: i8, expected: bool) {
+    fn is_adjacent_coords(x1: f32, y1: f32, x2: f32, y2: f32, expected: bool) {
         let result = Coordinate::is_adjacent(Coordinate::new(x1, y1), Coordinate::new(x2, y2));
         assert!(result == expected)
     }

--- a/engine/src/models/direction.rs
+++ b/engine/src/models/direction.rs
@@ -1,12 +1,12 @@
 #[derive(Clone, Default, Debug, Copy)]
 pub struct Direction {
-    pub dx: i8,
-    pub dy: i8,
+    pub dx: f32,
+    pub dy: f32,
 }
 
-pub const LEFT: Direction = Direction { dx: -1, dy: 0 };
-pub const RIGHT: Direction = Direction { dx: 1, dy: 0 };
-pub const UP: Direction = Direction { dx: 0, dy: -1 };
-pub const DOWN: Direction = Direction { dx: 0, dy: 1 };
+pub const LEFT: Direction = Direction { dx: -1.0, dy: 0.0 };
+pub const RIGHT: Direction = Direction { dx: 1.0, dy: 0.0 };
+pub const UP: Direction = Direction { dx: 0.0, dy: -1.0 };
+pub const DOWN: Direction = Direction { dx: 0.0, dy: 1.0 };
 
 impl Direction {}

--- a/engine/src/models/entity.rs
+++ b/engine/src/models/entity.rs
@@ -19,7 +19,7 @@ impl Default for Entity {
     fn default() -> Entity {
         Entity {
             id: 0,
-            coord: Coordinate::new(0, 0),
+            coord: Coordinate::new(0.0, 0.0),
             entity_type: EntityType::Player(1),
         }
     }
@@ -52,9 +52,9 @@ mod tests {
 
     #[test]
     fn create_new() {
-        let entity = Entity::new(1, Coordinate::new(2, 3));
+        let entity = Entity::new(1, Coordinate::new(2.0, 3.0));
         assert_eq!(1, entity.id);
-        assert_eq!(2, entity.coord.x);
-        assert_eq!(3, entity.coord.y);
+        assert!(entity.coord.is_at_x(2.0));
+        assert!(entity.coord.is_at_y(3.0));
     }
 }

--- a/engine/src/models/world.rs
+++ b/engine/src/models/world.rs
@@ -46,9 +46,7 @@ impl World {
     }
 
     pub fn on_coord(&self, coord: Coordinate) -> Option<&Entity> {
-        self.entities
-            .values()
-            .find(|entity| entity.coord.x == coord.x && entity.coord.y == coord.y)
+        self.entities.values().find(|entity| entity.coord == coord)
     }
 
     pub fn update_entity(&mut self, entity: Entity) {
@@ -89,11 +87,11 @@ mod tests {
     fn register_entity() {
         let mut world: World = World::new();
 
-        let entity = world.register(Entity::new(0, Coordinate::new(0, 0)));
+        let entity = world.register(Entity::new(0, Coordinate::new(0.0, 0.0)));
         assert_eq!(1, entity.id);
         assert_eq!(entity.id, world.get_entity(entity.id).unwrap().id);
 
-        let entity2 = world.register(Entity::new(0, Coordinate::new(0, 0)));
+        let entity2 = world.register(Entity::new(0, Coordinate::new(0.0, 0.0)));
         assert_eq!(2, entity2.id);
         assert_eq!(entity2.id, world.entities[&entity2.id].id);
     }

--- a/engine/src/serializers/basic.rs
+++ b/engine/src/serializers/basic.rs
@@ -8,7 +8,7 @@ pub fn print(world: &World) -> String {
     for y in 0..world.size_y {
         let mut line: Vec<String> = vec![];
         for x in 0..world.size_x {
-            line.push(coord_to_str(&world, x, y));
+            line.push(coord_to_str(&world, x as f32, y as f32));
         }
         lines.push(line.join(""));
     }
@@ -16,8 +16,8 @@ pub fn print(world: &World) -> String {
     lines.join("\n")
 }
 
-fn coord_to_str(world: &World, x: usize, y: usize) -> String {
-    match world.on_coord(Coordinate::new(x as i8, y as i8)) {
+fn coord_to_str(world: &World, x: f32, y: f32) -> String {
+    match world.on_coord(Coordinate::new(x, y)) {
         Some(entity) => match entity.entity_type {
             EntityType::Player(n) => n.to_string(),
             EntityType::Enemy(c) => c.to_string(),
@@ -36,14 +36,14 @@ pub fn load(raw: &str) -> World {
     lines
         .iter()
         .enumerate()
-        .for_each(|(y, line)| load_line(&mut world, y, &line));
+        .for_each(|(y, line)| load_line(&mut world, y as f32, &line));
 
     world
 }
 
-fn load_line(world: &mut World, y: usize, raw: &str) {
+fn load_line(world: &mut World, y: f32, raw: &str) {
     raw.chars().enumerate().for_each(|(x, c)| {
-        let coord = Coordinate::new(x as i8, y as i8);
+        let coord = Coordinate::new(x as f32, y);
         let entity: Option<Entity> = match c {
             '1' => Some(player::create_at(1, coord)),
             '2' => Some(player::create_at(2, coord)),
@@ -79,13 +79,13 @@ mod tests {
     #[test]
     fn print_world_with_actors() {
         let mut world = World::new();
-        world.register(player::create_at(1, Coordinate::new(1, 1)));
-        world.register(player::create_at(2, Coordinate::new(2, 1)));
-        world.register(mountain::create_at(Coordinate::new(4, 1)));
-        world.register(mountain::create_at(Coordinate::new(5, 1)));
-        world.register(water::create_at(Coordinate::new(4, 2)));
-        world.register(water::create_at(Coordinate::new(5, 2)));
-        world.register(bandid::create_at(Coordinate::new(5, 3)));
+        world.register(player::create_at(1, Coordinate::new(1.0, 1.0)));
+        world.register(player::create_at(2, Coordinate::new(2.0, 1.0)));
+        world.register(mountain::create_at(Coordinate::new(4.0, 1.0)));
+        world.register(mountain::create_at(Coordinate::new(5.0, 1.0)));
+        world.register(water::create_at(Coordinate::new(4.0, 2.0)));
+        world.register(water::create_at(Coordinate::new(5.0, 2.0)));
+        world.register(bandid::create_at(Coordinate::new(5.0, 3.0)));
 
         let result = print(&world);
 
@@ -112,31 +112,31 @@ mod tests {
         assert_eq!(world.size_y, 2);
         assert_eq!(world.has_actions(), false);
 
-        let player: Option<&Entity> = world.on_coord(Coordinate::new(0, 0));
+        let player: Option<&Entity> = world.on_coord(Coordinate::new(0.0, 0.0));
         assert!(player.is_some());
         if let Some(entity) = player {
             assert_eq!(entity.entity_type, EntityType::Player(1));
         }
 
-        let player2: Option<&Entity> = world.on_coord(Coordinate::new(1, 0));
+        let player2: Option<&Entity> = world.on_coord(Coordinate::new(1.0, 0.0));
         assert!(player2.is_some());
         if let Some(entity) = player2 {
             assert_eq!(entity.entity_type, EntityType::Player(2));
         }
 
-        let bandid: Option<&Entity> = world.on_coord(Coordinate::new(5, 1));
+        let bandid: Option<&Entity> = world.on_coord(Coordinate::new(5.0, 1.0));
         assert!(bandid.is_some());
         if let Some(entity) = bandid {
             assert_eq!(entity.entity_type, EntityType::Enemy('B'));
         }
 
-        let mountain: Option<&Entity> = world.on_coord(Coordinate::new(6, 1));
+        let mountain: Option<&Entity> = world.on_coord(Coordinate::new(6.0, 1.0));
         assert!(mountain.is_some());
         if let Some(entity) = mountain {
             assert_eq!(entity.entity_type, EntityType::Obstacle('#'));
         }
 
-        let water: Option<&Entity> = world.on_coord(Coordinate::new(7, 1));
+        let water: Option<&Entity> = world.on_coord(Coordinate::new(7.0, 1.0));
         assert!(water.is_some());
         if let Some(entity) = water {
             assert_eq!(entity.entity_type, EntityType::Hole('~'));

--- a/ggez-fe/src/main.rs
+++ b/ggez-fe/src/main.rs
@@ -79,8 +79,8 @@ impl MainState {
             },
         };
 
-        let x = START_X + f32::from(entity.coord.x) * ENTITY_SIZE + ENTITY_SIZE / 2.0;
-        let y = START_Y + f32::from(entity.coord.y) * ENTITY_SIZE + ENTITY_SIZE / 2.0;
+        let x = START_X + entity.coord.x * ENTITY_SIZE + ENTITY_SIZE / 2.0;
+        let y = START_Y + entity.coord.y * ENTITY_SIZE + ENTITY_SIZE / 2.0;
 
         let mesh = graphics::MeshBuilder::new()
             //.rectangle(graphics::DrawMode::Fill, graphics::Point2::new(100.0, 100.0), 100.0, 100.0, graphics::WHITE)


### PR DESCRIPTION
We need to perform several numeric calculations. I started to add
different numeric types per context, but that was proving troublesome
because in rust we can't easily make numeric operations with different
types.

This patch changes the coordinate and direction to f32. It also had to
add new logic to check equility because comparing floats has an error
margin.